### PR TITLE
break Dockerfile to test CI failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM alpine
+FROM alpine_ERROR
 
 CMD ["echo", "Hello from 2025cloud!"]


### PR DESCRIPTION
修改 alpine 成 alpine_ERROR，因為 alpine_ERROR 並不是一個有效的 base image，會導致 build 失敗。